### PR TITLE
Replacing onehot2int function for a synthesizable one

### DIFF
--- a/rtl/verilog/ahb3lite_interconnect_master_port.sv
+++ b/rtl/verilog/ahb3lite_interconnect_master_port.sv
@@ -138,11 +138,11 @@ module ahb3lite_interconnect_master_port #(
   //
   // Functions
   //
-  function integer onehot2int;
-    input [SLAVES-1:0] onehot;
-
-    for (onehot2int = -1; |onehot; onehot2int++) onehot = onehot >> 1;
-  endfunction //onehot2int
+   function integer onehot2int;
+      input grey_num;
+      integer grey_num,i;
+      for (i=0; i<32; i=i+1) if (grey_num[i]) onehot2int = i;
+   endfunction
 
 
   //////////////////////////////////////////////////////////////////

--- a/rtl/verilog/ahb3lite_interconnect_slave_port.sv
+++ b/rtl/verilog/ahb3lite_interconnect_slave_port.sv
@@ -122,11 +122,11 @@ module ahb3lite_interconnect_slave_port #(
   //
   // Functions
   //
-  function integer onehot2int;
-    input [SLAVES-1:0] onehot;
-
-    for (onehot2int = -1; |onehot; onehot2int++) onehot = onehot >>1;
-  endfunction //onehot2int
+   function integer onehot2int;
+      input grey_num;
+      integer grey_num,i;
+      for (i=0; i<32; i=i+1) if (grey_num[i]) onehot2int = i;
+   endfunction
 
 
   function [2:0] highest_requested_priority (


### PR DESCRIPTION
I have tried synthesizing the code on Vivado 2017.4 and, although the simulation works just fine, the code doesn't synthesize. More troublesomely, it doesn't even complain and it took me several hours of debugging to understand where the problem was... After that, I followed the suggestion on [http://www.edaboard.co.uk/one-hot-to-binary-t115682.html](http://www.edaboard.co.uk/one-hot-to-binary-t115682.html) and it changed the function basing on that code, which synthesized just fine.