### PR TITLE
Prioritize lower indexed slaves when memory map overlaps

### DIFF
--- a/rtl/verilog/ahb3lite_interconnect_master_port.sv
+++ b/rtl/verilog/ahb3lite_interconnect_master_port.sv
@@ -321,6 +321,14 @@ generate
 endgenerate
 
   /*
+   * Ensure only one slave bit set per master. Lowest set bit will have precedence.
+   * This will prioritize lower indexed slaves and prevent overlapping memory maps
+   * from causing issues.
+   */
+  assign current_HSEL = -current_HSEL & current_HSEL;
+  assign pending_HSEL = -pending_HSEL & pending_HSEL;
+
+  /*
    * Check if granted access
    */
   always @(posedge HCLK,negedge HRESETn)


### PR DESCRIPTION
Not sure if this has other unintended consequences. Seems to work in my minimal testing. I specify a catch-all slave in the last index which receives unmatched transactions. This may not be useful to others but thought I'd pass it on as I saw the TODO note on line 306.